### PR TITLE
Added delete function to Supporting Document API

### DIFF
--- a/tranxacto-docs/src/main/java/com/zedapps/txdocs/controller/SupportingDocumentController.java
+++ b/tranxacto-docs/src/main/java/com/zedapps/txdocs/controller/SupportingDocumentController.java
@@ -65,4 +65,17 @@ public class SupportingDocumentController {
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; fileName=" + supportingDocument.get().getName())
                 .body(supportingDocument.get().getData());
     }
+
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<Object> removeFile(@PathVariable long id) {
+        Optional<SupportingDocument> document = supportingDocumentService.getFile(id);
+
+        if (document.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Invalid id passed for deletion!");
+        }
+
+        supportingDocumentService.removeFile(document.get());
+
+        return ResponseEntity.ok("Successfully deleted!");
+    }
 }

--- a/tranxacto-docs/src/main/java/com/zedapps/txdocs/service/SupportingDocumentService.java
+++ b/tranxacto-docs/src/main/java/com/zedapps/txdocs/service/SupportingDocumentService.java
@@ -51,6 +51,11 @@ public class SupportingDocumentService {
         return getSupportingDocumentDto(doc);
     }
 
+    @Transactional
+    public void removeFile(SupportingDocument document) {
+        supportingDocumentRepository.delete(document);
+    }
+
     private static SupportingDocumentDto getSupportingDocumentDto(SupportingDocument doc) {
         return ResponseUtils.getSupportingDocumentResponse(doc.getId(), doc.getName(), doc.getSize(), doc.getUploadDate());
     }


### PR DESCRIPTION
The following endpoint has been added to the API, which allows for deletion of uploaded Supporting Documents.

* /delete/{id} - DELETE - deletes document specified by id