### PR TITLE
Implemented Gateway Server with Spring Cloud Gateway

### DIFF
--- a/tranxacto-gateway/build.gradle
+++ b/tranxacto-gateway/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.7'
     id 'io.spring.dependency-management' version '1.1.0'
 }
 
@@ -11,12 +10,12 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '2.7.7'
-    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-eureka-client', version: '3.1.4'
+    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-gateway', version: '4.0.4'
+    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-eureka-client', version: '4.0.1'
 }
 
 dependencyManagement {
     imports {
-        mavenBom "org.springframework.cloud:spring-cloud-dependencies:2021.0.6"
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:2022.0.2"
     }
 }

--- a/tranxacto-gateway/build.gradle
+++ b/tranxacto-gateway/build.gradle
@@ -10,8 +10,13 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-gateway', version: '4.0.4'
+    implementation (group: 'org.springframework.cloud', name: 'spring-cloud-starter-gateway', version: '4.0.4') {
+        exclude group: 'com.google', module: 'gson'
+    }
+
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-eureka-client', version: '4.0.1'
+
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
 }
 
 dependencyManagement {

--- a/tranxacto-gateway/build.gradle
+++ b/tranxacto-gateway/build.gradle
@@ -13,7 +13,6 @@ repositories {
 dependencies {
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '2.7.7'
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-eureka-client', version: '3.1.4'
-    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-zuul', version: '2.2.10.RELEASE'
 }
 
 dependencyManagement {

--- a/tranxacto-gateway/src/main/java/com/zedapps/txgateway/AppRunner.java
+++ b/tranxacto-gateway/src/main/java/com/zedapps/txgateway/AppRunner.java
@@ -3,7 +3,6 @@ package com.zedapps.txgateway;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
-import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
 
 /**
  * @author Shamah M Zoha
@@ -11,7 +10,6 @@ import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
  */
 
 @SpringBootApplication
-@EnableZuulProxy
 @EnableDiscoveryClient
 public class AppRunner {
 

--- a/tranxacto-gateway/src/main/resources/application.properties
+++ b/tranxacto-gateway/src/main/resources/application.properties
@@ -1,14 +1,16 @@
 server.port=8059
-spring.application.name=zuul-gateway-server
-eureka.instance.instance-id=zuul-gateway-server
+spring.application.name=gateway-server
+eureka.instance.instance-id=gateway-server
 eureka.client.service-url.defaultZone=http://localhost:8050/eureka/
 
 # Disable service access through service name
-zuul.ignored-services=*
+spring.cloud.gateway.discovery.locator.enabled=false
 
 # Service path mapping
-zuul.routes.account-api.path=/account/**
-zuul.routes.account-api.service-id=account-api
+spring.cloud.gateway.routes[0].id=account-api
+spring.cloud.gateway.routes[0].uri=http://localhost:8051/
+spring.cloud.gateway.routes[0].predicates[0]=Path=/account/**
 
-zuul.routes.supporting-docs-api.path=/docs/**
-zuul.routes.supporting-docs-api.service-id=supporting-docs-api
+spring.cloud.gateway.routes[1].id=supporting-docs-api
+spring.cloud.gateway.routes[1].uri=http://localhost:8052/
+spring.cloud.gateway.routes[1].predicates[0]=Path=/docs/**


### PR DESCRIPTION
Previously, the Gateway Server was implemented using Spring Netflix Zuul library. However, this library is severely outdated, causing various issues with the version of Spring Boot being used, the JDK used to build the project, and so on.

The Gateway Server also did not work as intended due to these issues.

As a result, the server was re-implemented, with the latest library of Spring Cloud Gateway being used. The Eureka & Spring Cloud dependencies were also updated.